### PR TITLE
Fix Safari 8

### DIFF
--- a/hamster.js
+++ b/hamster.js
@@ -201,7 +201,7 @@ Hamster.normalise = {
    * @returns {Object}      event
    */
    event: function normaliseEvent(originalEvent){
-    var event = Hamster.SUPPORT === 'wheel' ? originalEvent : {
+    var event = {
           // keep a reference to the original event object
           originalEvent: originalEvent,
           target: originalEvent.target || originalEvent.srcElement,


### PR DESCRIPTION
This fixes Hamster in Safari 8, where, as per the spec, the `deltaY` and `deltaX` properties of the `WheelEvent` object cannot be overriden. 

Although I haven't measured it, this _could_ have a slight negative impact on performance in modern browsers since we're creating an object at every wheel event which was previously avoided.
