### PR TITLE
Avoid to return NaN

### DIFF
--- a/hamster.js
+++ b/hamster.js
@@ -286,6 +286,11 @@ Hamster.normalise = {
       delta = originalEvent.detail * -1;
     }
 
+    // Avoid to return NaN
+    if (delta === 0) {
+    	return [0, 0, 0];
+    }
+
     // look for lowest delta to normalize the delta values
     absDelta = Math.abs(delta);
     if (!lowestDelta || absDelta < lowestDelta) {


### PR DESCRIPTION
Fix #6, #7 

We don't have to calculate deltaX and deltaY when delta is equal to 0.
This also avoid to return NaN in case delta and lowestDelta are both 0.

Note that for Chrome version 46 with OS/X touchpad, there is a delta
0 event will be triggered before the inertia events start.

<img width="584" alt="screen shot 2015-10-25 at 3 43 29 am" src="https://cloud.githubusercontent.com/assets/1492892/10712408/25ed5978-7acd-11e5-83ed-5699fc8288ea.png">

Signed-off-by: kfei <kfei@kfei.net>