### PR TITLE
Fix: Google Chrome passive event listener error

### DIFF
--- a/hamster.js
+++ b/hamster.js
@@ -125,7 +125,7 @@ Hamster.event = {
     };
 
     // cross-browser addEventListener
-    hamster.element[Hamster.ADD_EVENT](Hamster.PREFIX + eventName, handler, useCapture || false);
+    hamster.element[Hamster.ADD_EVENT](Hamster.PREFIX + eventName, handler, useCapture || { passive: false });
 
     // store original and normalised handlers on the instance
     hamster.handlers.push({


### PR DESCRIPTION
Fix "Unable to preventDefault inside passive event listener due to target being treated as passive." error in Google Chrome.